### PR TITLE
move flutter official gallery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ And note there are some [limitations](https://github.com/X-Wei/flutter_catalog/i
 
 This app is written with reference to many resources, including:
 
-* Offical gallery app: https://github.com/flutter/flutter/tree/master/examples/flutter_gallery
+* Offical gallery app: https://github.com/flutter/gallery
 * Andrea Bizzotto's YouTube channel: https://www.youtube.com/channel/UCrTnsT4OYZ53l0QGKqLeD5Q
 * Tensor Programming's YouTube channel: https://www.youtube.com/watch?v=WwhyaqNtNQY&list=PLJbE2Yu2zumDqr_-hqpAN0nIr6m14TAsd
 * Eajy's flutter demo: https://github.com/Eajy/flutter_demo


### PR DESCRIPTION
Official gallery app page returned 404.
separate other repositories. https://github.com/flutter/gallery

↓ official page
[Flutter gallery The flutter gallery app no longer lives in this repo. Please see the gallery repo.](https://github.com/flutter/flutter/tree/master/examples#:~:text=Flutter%20gallery%20The%20flutter%20gallery%20app%20no%20longer%20lives%20in%20this%20repo.%20Please%20see%20the%20gallery%20repo.)
