### PR TITLE
Master raheem

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     // Cf. https://github.com/flutter/flutter/issues/53657#issuecomment-642236438
     ndkVersion '21.3.6528147'
 

--- a/lib/routes/widgets_textfield_ex.dart
+++ b/lib/routes/widgets_textfield_ex.dart
@@ -23,8 +23,7 @@ class _TextFieldExampleState extends State<TextFieldExample> {
           borderRadius: BorderRadius.all(Radius.circular(10.0)),
         ),
       ),
-      onSubmitted: (val) =>
-          Fluttertoast.showToast(msg: 'You entered: ${int.parse(val)}'),
+      onSubmitted: (val) => Fluttertoast.showToast(msg: 'You entered: ${int.parse(val)}'),
       onChanged: (String val) {
         final v = int.tryParse(val);
         debugPrint('parsed value = $v');
@@ -45,13 +44,23 @@ class _TextFieldExampleState extends State<TextFieldExample> {
       maxLines: 10,
       textCapitalization: TextCapitalization.sentences,
       decoration: InputDecoration(
-        counterText: '${this._controller.text.split(' ').length} words',
+        counterText: '${_countWords(text: this._controller.text)} words',
         labelText: 'Enter multiline text:',
+        alignLabelWithHint: true,
         hintText: 'type something...',
         border: const OutlineInputBorder(),
       ),
       onChanged: (text) => setState(() {}),
     );
+  }
+
+  int _countWords({required String text}) {
+    final trimmedText = text.trim();
+    if (trimmedText.isEmpty) {
+      return 0;
+    } else {
+      return trimmedText.split(RegExp("\\s+")).length;
+    }
   }
 
   bool _showPassword = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -832,6 +832,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:


### PR DESCRIPTION
Fix the "Basics -> Widgets -> TextField shows incorrect count of words #125"

The second Multiline input field counts words incorrectly:

it always shows 1 even there is no words
it doesn't count the word when you get down to new line (like pressing enter)
also placeholder text or hint is displayed in the middle of the TextInput, it would be nice if its gravity set to start and top.