### PR TITLE
fix: dispose auth subscription and TextEditingControllers (closes #173, #174)

### DIFF
--- a/lib/routes/firebase_login_ex.dart
+++ b/lib/routes/firebase_login_ex.dart
@@ -23,15 +23,23 @@ class _FirebaseLoginExampleState extends State<FirebaseLoginExample> {
   // If this._busy=true, the buttons are not clickable. This is to avoid
   // clicking buttons while a previous onTap function is not finished.
   bool _busy = false;
+  late final StreamSubscription<firebase_auth.User?> _authSub;
 
   @override
   void initState() {
     super.initState();
     this._user = _auth.currentUser;
-    _auth.authStateChanges().listen((firebase_auth.User? usr) {
-      this._user = usr;
-      debugPrint('user=$_user');
+    _authSub = _auth.authStateChanges().listen((firebase_auth.User? usr) {
+      debugPrint('user=$usr');
+      if (!mounted) return;
+      setState(() => this._user = usr);
     });
+  }
+
+  @override
+  void dispose() {
+    _authSub.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/routes/networking_rest_api_send_ex.dart
+++ b/lib/routes/networking_rest_api_send_ex.dart
@@ -28,6 +28,14 @@ class _RestApiSendExampleState extends State<RestApiSendExample> {
   }
 
   @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    _userIdController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
## Context

This PR is part of an academic analysis of Flutter Catalog conducted for a
mobile development course (ISIS3510, Universidad de los Andes). The focus is
correctness rather than new features. Both changes are confined to the two
files that the linked issues describe; no demo behavior or educational
content is altered beyond what the issues already discussed.

## Summary

Closes #173 and #174. Two independent memory-leak fixes:

### 1. `lib/routes/firebase_login_ex.dart` (#173)

`_auth.authStateChanges().listen(...)` previously returned a `StreamSubscription`
that was discarded, and the listener mutated `this._user` without `setState`,
so:

- the subscription leaked every time the route was opened, and
- the UI never reflected auth state changes pushed through the stream
  (sign-out from another tab, token expiration, etc.).

The fix:

- Stores the subscription in a `_authSub` field.
- Overrides `dispose()` to cancel it.
- Calls `setState` from the listener so the displayed status text reacts to
  external auth state changes.
- Adds a `mounted` guard before `setState` so callbacks that race with
  navigation do not touch a disposed widget.

### 2. `lib/routes/networking_rest_api_send_ex.dart` (#174)

Three `TextEditingController` instances were created in `initState()` but
the widget never overrode `dispose()`. `TextEditingController` is a
`ChangeNotifier` retained by every `TextField` that listens to it. The fix
overrides `dispose()` and releases the three controllers.

## Test plan

- [x] `git diff` reviewed — only the two files are touched, additions only
  (no behavior removed from the demos).
- [ ] `flutter analyze lib/routes/firebase_login_ex.dart lib/routes/networking_rest_api_send_ex.dart`
  — could not run locally because the project requires Flutter SDK >=3.11
  and the local environment is on 3.10. The diff is small and uses only
  standard `StatefulWidget` patterns (no Dart 3.11 syntax).
- [ ] Manual run of the Firebase Login demo on a physical device to confirm
  that the status text now updates immediately when auth state changes
  through the stream.
- [ ] DevTools Memory snapshot to confirm `_FirebaseLoginExampleState` and
  `_RestApiSendExampleState` instances are GC'd after navigating away from
  each demo.

Made with [Cursor](https://cursor.com)